### PR TITLE
Allow for external Stokes I model

### DIFF
--- a/RMtools_1D/do_RMsynth_1D.py
+++ b/RMtools_1D/do_RMsynth_1D.py
@@ -174,8 +174,12 @@ def run_rmsynth(data, polyOrd=2, phiMax_radm2=None, dPhi_radm2=None,
 
     # Plot the data and the Stokes I model fit
     if verbose: log("Plotting the input data and spectral index fit.")
-    freqHirArr_Hz =  np.linspace(freqArr_Hz[0], freqArr_Hz[-1], 10000)
-    IModHirArr = calculate_StokesI_model(fitDict,freqHirArr_Hz)
+    if modStokesI is None:
+        freqHirArr_Hz =  np.linspace(freqArr_Hz[0], freqArr_Hz[-1], 10000)
+        IModHirArr = calculate_StokesI_model(fitDict,freqHirArr_Hz)
+    elif modStokesI is not None:
+        IModHirArr = modStokesI
+        IModHirArr = freqArr_Hz
     if showPlots or saveFigures:
         specFig = plt.figure(facecolor='w',figsize=(12.0, 8))
         plot_Ipqu_spectra_fig(freqArr_Hz     = freqArr_Hz,

--- a/RMtools_1D/do_RMsynth_1D.py
+++ b/RMtools_1D/do_RMsynth_1D.py
@@ -69,7 +69,7 @@ C = 2.997924538e8 # Speed of light [m/s]
 #-----------------------------------------------------------------------------#
 def run_rmsynth(data, polyOrd=2, phiMax_radm2=None, dPhi_radm2=None,
                 nSamples=10.0, weightType="variance", fitRMSF=False,
-                noStokesI=False, phiNoise_radm2=1e6, nBits=32, showPlots=False,
+                noStokesI=False, modStokesI=None, phiNoise_radm2=1e6, nBits=32, showPlots=False,
                 debug=False, verbose=False, log=print,units='Jy/beam', 
                 prefixOut="prefixOut", saveFigures=None,fit_function='log'):
     """Run RM synthesis on 1D data.
@@ -102,6 +102,7 @@ def run_rmsynth(data, polyOrd=2, phiMax_radm2=None, dPhi_radm2=None,
             "uniform" -- Weight uniformly (i.e. with 1s)
         fitRMSF (bool): Fit a Gaussian to the RMSF?
         noStokesI (bool: Is Stokes I data provided?
+        modStokesI (array_like): Stokes I model across for each channel (optional)
         phiNoise_radm2 (float): ????
         nBits (int): Precision of floating point numbers.
         showPlots (bool): Show plots?
@@ -163,7 +164,9 @@ def run_rmsynth(data, polyOrd=2, phiMax_radm2=None, dPhi_radm2=None,
                                  polyOrd  = polyOrd,
                                  verbose  = True,
                                  debug    = debug,
-                             fit_function = fit_function)
+                                 fit_function = fit_function,
+                                 modStokesI = modStokesI,
+                                 )
              
     dquArr = (dqArr + duArr)/2.0
     dquArr= np.where(np.isfinite(dquArr),dquArr,np.nan)

--- a/RMtools_1D/do_RMsynth_1D.py
+++ b/RMtools_1D/do_RMsynth_1D.py
@@ -179,7 +179,7 @@ def run_rmsynth(data, polyOrd=2, phiMax_radm2=None, dPhi_radm2=None,
         IModHirArr = calculate_StokesI_model(fitDict,freqHirArr_Hz)
     elif modStokesI is not None:
         IModHirArr = modStokesI
-        IModHirArr = freqArr_Hz
+        freqHirArr_Hz = freqArr_Hz
     if showPlots or saveFigures:
         specFig = plt.figure(facecolor='w',figsize=(12.0, 8))
         plot_Ipqu_spectra_fig(freqArr_Hz     = freqArr_Hz,

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -996,7 +996,7 @@ def create_pqu_resid_RMthin(qArr, uArr, freqArr_Hz, fracPol, psi0_deg,
 #-----------------------------------------------------------------------------#
 def xfloat(x, default=None):
 
-    if x is None or x is "":
+    if x is None or x=="":
         return default
     try:
         return float(x)

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -439,7 +439,15 @@ def create_frac_spectra(freqArr, IArr, QArr, UArr, dIArr, dQArr, dUArr,
     if modStokesI is not None:
         # Use provided model
         IModArr = modStokesI
-        fitDict = {}
+        fitDict = {"fitStatus": 0,
+            "chiSq": 0.0,
+            "dof": len(freqArr)-polyOrd-1,
+            "chiSqRed": 0.0,
+            "nIter": 0,
+            "p": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0], #default if fail: flat 1s.
+            "polyOrd":polyOrd,
+            "AIC":0,
+            "reference_frequency_Hz":1}
         if verbose:
             print('Using provided model Stokes I spectrum')
     else:

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -430,50 +430,57 @@ def renormalize_StokesI_model(fitDict,new_reference_frequency):
 
 #-----------------------------------------------------------------------------#
 def create_frac_spectra(freqArr, IArr, QArr, UArr, dIArr, dQArr, dUArr,
-                        polyOrd=2, verbose=False, debug=False,fit_function="log"):
+                        polyOrd=2, verbose=False, debug=False,fit_function="log",
+                        modStokesI=None
+                        ):
     """Fit the Stokes I spectrum with a polynomial and divide into the Q & U
     spectra to create fractional spectra."""
 
+    if modStokesI:
+        # Use provided model
+        IModArr = modStokesI
+        if verbose:
+            print('Using provided model Stokes I spectrum')
+    else:
+        # Fit a <=5th order polynomial model to the Stokes I spectrum
+        try:
+            fitDict=fit_StokesI_model(freqArr,IArr,dIArr,polyOrd,fit_function)
+            IModArr = calculate_StokesI_model(fitDict,freqArr)
+            
+            if np.min(IModArr) < 0:   #Flag sources with negative models.
+                fitDict["fitStatus"] += 128
+            if (IModArr < dIArr).sum() > 0:  #Flag sources with models with S/N < 1.
+            #TODO: this can be made better: estimating the error on the model to see
+            # if the model is within 1 sigma, rather than the data error bars.
+                fitDict["fitStatus"] += 64
 
-    # Fit a <=5th order polynomial model to the Stokes I spectrum
-    try:
-        fitDict=fit_StokesI_model(freqArr,IArr,dIArr,polyOrd,fit_function)
-        IModArr = calculate_StokesI_model(fitDict,freqArr)
-        
-        if np.min(IModArr) < 0:   #Flag sources with negative models.
-            fitDict["fitStatus"] += 128
-        if (IModArr < dIArr).sum() > 0:  #Flag sources with models with S/N < 1.
-        #TODO: this can be made better: estimating the error on the model to see
-        # if the model is within 1 sigma, rather than the data error bars.
-            fitDict["fitStatus"] += 64
-
-        #if verbose:
-        #    print("\n")
-        #    print("-"*80)
-        #    print("Details of the polynomial fit to the spectrum:")
-        #    for key, val in fitDict.iteritems():
-        #        print(" %s = %s" % (key, val))
-        #    print("-"*80)
-        #    print("\n")
-    except Exception:  #If fit fails, fallback:
-        print("Err: Failed to fit polynomial to Stokes I spectrum.")
-        if debug:
-            print("\nTRACEBACK:")
-            print(("-" * 80))
-            print((traceback.format_exc()))
-            print(("-" * 80))
-            print("\n")
-        print("> Setting Stokes I spectrum to unity.\n")
-        fitDict = {"fitStatus": 9, #indicate failure
-               "chiSq": 0.0,
-               "dof": len(freqArr)-polyOrd-1,
-               "chiSqRed": 0.0,
-               "nIter": 0,
-               "p": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0], #default if fail: flat 1s.
-               "polyOrd":polyOrd,
-               "AIC":0,
-               "reference_frequency_Hz":1}
-        IModArr = np.ones_like(IArr)
+            #if verbose:
+            #    print("\n")
+            #    print("-"*80)
+            #    print("Details of the polynomial fit to the spectrum:")
+            #    for key, val in fitDict.iteritems():
+            #        print(" %s = %s" % (key, val))
+            #    print("-"*80)
+            #    print("\n")
+        except Exception:  #If fit fails, fallback:
+            print("Err: Failed to fit polynomial to Stokes I spectrum.")
+            if debug:
+                print("\nTRACEBACK:")
+                print(("-" * 80))
+                print((traceback.format_exc()))
+                print(("-" * 80))
+                print("\n")
+            print("> Setting Stokes I spectrum to unity.\n")
+            fitDict = {"fitStatus": 9, #indicate failure
+                "chiSq": 0.0,
+                "dof": len(freqArr)-polyOrd-1,
+                "chiSqRed": 0.0,
+                "nIter": 0,
+                "p": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0], #default if fail: flat 1s.
+                "polyOrd":polyOrd,
+                "AIC":0,
+                "reference_frequency_Hz":1}
+            IModArr = np.ones_like(IArr)
     
     # Calculate the fractional spectra and errors
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -436,7 +436,7 @@ def create_frac_spectra(freqArr, IArr, QArr, UArr, dIArr, dQArr, dUArr,
     """Fit the Stokes I spectrum with a polynomial and divide into the Q & U
     spectra to create fractional spectra."""
 
-    if modStokesI:
+    if modStokesI is not None:
         # Use provided model
         IModArr = modStokesI
         if verbose:

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -450,7 +450,7 @@ def create_frac_spectra(freqArr, IArr, QArr, UArr, dIArr, dQArr, dUArr,
             "reference_frequency_Hz":1}
         if verbose:
             print('Using provided model Stokes I spectrum')
-    else:
+    elif modStokesI is None:
         # Fit a <=5th order polynomial model to the Stokes I spectrum
         try:
             fitDict=fit_StokesI_model(freqArr,IArr,dIArr,polyOrd,fit_function)

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -439,6 +439,7 @@ def create_frac_spectra(freqArr, IArr, QArr, UArr, dIArr, dQArr, dUArr,
     if modStokesI is not None:
         # Use provided model
         IModArr = modStokesI
+        fitDict = {}
         if verbose:
             print('Using provided model Stokes I spectrum')
     else:


### PR DESCRIPTION
Allow for an externally generated Stokes I model to passed as the model -- Skips the Stokes I fitting stage. 

I've currently just implemented this in the API -- with no command-line option. We may want the ability to point to e.g. an extra file with a model, but I've left that out for now.