### PR TITLE
New QU-fitting models, and minor bug fix

### DIFF
--- a/RMtools_1D/do_QUfit_1D_mnest.py
+++ b/RMtools_1D/do_QUfit_1D_mnest.py
@@ -231,7 +231,7 @@ def load_model(modelNum, verbose=False):
             spec.loader.exec_module(mod)
         except:
             print(
-                "Model could not be found! Please make sure model is present either in {}/models_ns/, or in {}/RMtools_1D/models_ns/".format(
+                "Model could not be found! Please make sure model is present either in {}/models_ns/, or in {}/models_ns/".format(
                     os.getcwd(), RMtools_dir
                 )
             )

--- a/RMtools_1D/models_ns/m1.py
+++ b/RMtools_1D/models_ns/m1.py
@@ -39,7 +39,7 @@ def model(pDict, lamSqArr_m2):
 #-----------------------------------------------------------------------------#
 priors = {
     "fracPol": bilby.prior.Uniform(
-        minimum=0.001, 
+        minimum=0.0, 
         maximum=1.0, 
         name="fracPol", 
         latex_label="$p$"

--- a/RMtools_1D/models_ns/m1.py
+++ b/RMtools_1D/models_ns/m1.py
@@ -12,7 +12,16 @@ import bilby
 #  quArr       = Complex array containing the Re and Im spectra.              #
 #-----------------------------------------------------------------------------#
 def model(pDict, lamSqArr_m2):
-    """Simple Faraday thin source."""
+    """
+    
+    Simple Faraday thin source
+    
+    Ref:
+    Sokoloff et al. (1998) Eq 2
+    O'Sullivan et al. (2012) Eq 8
+    Ma et al. (2019a) Eq 10
+    
+    """
 
     # Calculate the complex fractional q and u spectra
     pArr = pDict["fracPol"] * np.ones_like(lamSqArr_m2)

--- a/RMtools_1D/models_ns/m11.py
+++ b/RMtools_1D/models_ns/m11.py
@@ -64,13 +64,13 @@ def converter(parameters):
 priors = PriorDict(conversion_function=converter)
 
 priors['fracPol1'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol1',
     latex_label='$p_1$',
 )
 priors['fracPol2'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol2',
     latex_label='$p_2$',
@@ -110,7 +110,7 @@ priors['delta_RM1_RM2_radm2'] = Constraint(
     latex_label="$\Delta\phi_{1,2}$ (rad m$^{-2}$)",
 )
 priors['sum_p1_p2'] = Constraint(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1,
     name="sum_p1_p2",
     latex_label="$p_1+p_2$)",

--- a/RMtools_1D/models_ns/m111.py
+++ b/RMtools_1D/models_ns/m111.py
@@ -68,19 +68,19 @@ def converter(parameters):
 priors = PriorDict(conversion_function=converter)
 
 priors['fracPol1'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol1',
     latex_label='$p_1$',
 )
 priors['fracPol2'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol2',
     latex_label='$p_2$',
 )
 priors['fracPol3'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol3',
     latex_label='$p_3$',
@@ -139,7 +139,7 @@ priors['delta_RM2_RM3_radm2'] = Constraint(
     latex_label="$\Delta\phi_{1,2}$ (rad m$^{-2}$)",
 )
 priors['sum_p1_p2_p3'] = Constraint(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1,
     name="sum_p1_p2_p3",
     latex_label="$p_1+p_2+p_3$)",

--- a/RMtools_1D/models_ns/m111.py
+++ b/RMtools_1D/models_ns/m111.py
@@ -1,0 +1,146 @@
+#=============================================================================#
+#                          MODEL DEFINITION FILE                              #
+#=============================================================================#
+import numpy as np
+import bilby
+from bilby.core.prior import PriorDict, Constraint
+
+#-----------------------------------------------------------------------------#
+# Function defining the model.                                                #
+#                                                                             #
+#  pDict       = Dictionary of parameters, created by parsing inParms, below. #
+#  lamSqArr_m2 = Array of lambda-squared values                               #
+#  quArr       = Complex array containing the Re and Im spectra.              #
+#-----------------------------------------------------------------------------#
+def model(pDict, lamSqArr_m2):
+    """
+    
+    Three separate Faraday thin sources
+    Averaged within the same telescope beam (i.e., unresolved)
+    
+    Ref (for individual source component):
+    Sokoloff et al. (1998) Eq 2
+    O'Sullivan et al. (2012) Eq 8
+    Ma et al. (2019a) Eq 10
+    
+    """
+    
+    # Calculate the complex fractional q and u spectra
+    pArr1 = pDict["fracPol1"] * np.ones_like(lamSqArr_m2)
+    pArr2 = pDict["fracPol2"] * np.ones_like(lamSqArr_m2)
+    pArr3 = pDict["fracPol3"] * np.ones_like(lamSqArr_m2)
+    quArr1 = pArr1 * np.exp( 2j * (np.radians(pDict["psi01_deg"]) +
+                                   pDict["RM1_radm2"] * lamSqArr_m2))
+    quArr2 = pArr2 * np.exp( 2j * (np.radians(pDict["psi02_deg"]) +
+                                   pDict["RM2_radm2"] * lamSqArr_m2))
+    quArr3 = pArr3 * np.exp( 2j * (np.radians(pDict["psi03_deg"]) +
+                                   pDict["RM3_radm2"] * lamSqArr_m2))
+    quArr = (quArr1 + quArr2 + quArr3)
+    
+    return quArr
+
+
+#-----------------------------------------------------------------------------#
+# Priors for the above model.                                                 #
+# See https://lscsoft.docs.ligo.org/bilby/prior.html for details.             #
+#                                                                             #
+#-----------------------------------------------------------------------------#
+def converter(parameters):
+    """
+    Function to convert between sampled parameters and constraint parameter.
+
+    Parameters
+    ----------
+    parameters: dict
+        Dictionary containing sampled parameter values, 'RM1_radm2', 'RM2_radm2',
+        'RM3_radm2', 'fracPol1', 'fracPol2', 'fracPol3'
+
+    Returns
+    -------
+    dict: Dictionary with constraint parameter 'delta_RM1_RM2_radm2' and 'sum_p1_p2_p3' added.
+    """
+    converted_parameters = parameters.copy()
+    converted_parameters['delta_RM1_RM2_radm2'] = parameters['RM1_radm2'] - parameters['RM2_radm2']
+    converted_parameters['delta_RM2_RM3_radm2'] = parameters['RM2_radm2'] - parameters['RM3_radm2']
+    converted_parameters['sum_p1_p2_p3'] = parameters['fracPol1'] + parameters['fracPol2'] + parameters['fracPol3']
+    return converted_parameters
+
+priors = PriorDict(conversion_function=converter)
+
+priors['fracPol1'] = bilby.prior.Uniform(
+    minimum=0.001,
+    maximum=1.0,
+    name='fracPol1',
+    latex_label='$p_1$',
+)
+priors['fracPol2'] = bilby.prior.Uniform(
+    minimum=0.001,
+    maximum=1.0,
+    name='fracPol2',
+    latex_label='$p_2$',
+)
+priors['fracPol3'] = bilby.prior.Uniform(
+    minimum=0.001,
+    maximum=1.0,
+    name='fracPol3',
+    latex_label='$p_3$',
+)
+
+priors['psi01_deg'] = bilby.prior.Uniform(
+    minimum=0,
+    maximum=180.0,
+    name="psi01_deg",
+    latex_label="$\psi_{0,1}$ (deg)",
+    boundary="periodic",
+)
+priors['psi02_deg'] = bilby.prior.Uniform(
+    minimum=0,
+    maximum=180.0,
+    name="psi02_deg",
+    latex_label="$\psi_{0,2}$ (deg)",
+    boundary="periodic",
+)
+priors['psi03_deg'] = bilby.prior.Uniform(
+    minimum=0,
+    maximum=180.0,
+    name="psi03_deg",
+    latex_label="$\psi_{0,3}$ (deg)",
+    boundary="periodic",
+)
+
+priors['RM1_radm2'] = bilby.prior.Uniform(
+    minimum=-1100.0,
+    maximum=1100.0,
+    name="RM1_radm2",
+    latex_label="$\phi_1$ (rad m$^{-2}$)",
+)
+priors['RM2_radm2'] = bilby.prior.Uniform(
+    minimum=-1100.0,
+    maximum=1100.0,
+    name="RM2_radm2",
+    latex_label="$\phi_2$ (rad m$^{-2}$)",
+)
+priors['RM3_radm2'] = bilby.prior.Uniform(
+    minimum=-1100.0,
+    maximum=1100.0,
+    name="RM3_radm2",
+    latex_label="$\phi_3$ (rad m$^{-2}$)",
+)
+priors['delta_RM1_RM2_radm2'] = Constraint(
+    minimum=0,
+    maximum=2200.0,
+    name="delta_RM1_RM2_radm2",
+    latex_label="$\Delta\phi_{1,2}$ (rad m$^{-2}$)",
+)
+priors['delta_RM2_RM3_radm2'] = Constraint(
+    minimum=0,
+    maximum=2200.0,
+    name="delta_RM2_RM3_radm2",
+    latex_label="$\Delta\phi_{1,2}$ (rad m$^{-2}$)",
+)
+priors['sum_p1_p2_p3'] = Constraint(
+    minimum=0.001,
+    maximum=1,
+    name="sum_p1_p2_p3",
+    latex_label="$p_1+p_2+p_3$)",
+)

--- a/RMtools_1D/models_ns/m2.py
+++ b/RMtools_1D/models_ns/m2.py
@@ -41,7 +41,7 @@ def model(pDict, lamSqArr_m2):
 #-----------------------------------------------------------------------------#
 priors = {
     "fracPol": bilby.prior.Uniform(
-        minimum=0.001, 
+        minimum=0.0, 
         maximum=1.0, 
         name="fracPol", 
         latex_label="$p$"

--- a/RMtools_1D/models_ns/m3.py
+++ b/RMtools_1D/models_ns/m3.py
@@ -66,13 +66,13 @@ def converter(parameters):
 priors = PriorDict(conversion_function=converter)
 
 priors['fracPol1'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol1',
     latex_label='$p_1$',
 )
 priors['fracPol2'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol2',
     latex_label='$p_2$',
@@ -119,7 +119,7 @@ priors['sigmaRM_radm2'] = bilby.prior.Uniform(
     latex_label="$\sigma_{RM}$ (rad m$^{-2}$)",
 )
 priors['sum_p1_p2'] = Constraint(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1,
     name="sum_p1_p2",
     latex_label="$p_1+p_2$)",

--- a/RMtools_1D/models_ns/m3.py
+++ b/RMtools_1D/models_ns/m3.py
@@ -13,8 +13,19 @@ from bilby.core.prior import PriorDict, Constraint
 #  quArr       = Complex array containing the Re and Im spectra.              #
 #-----------------------------------------------------------------------------#
 def model(pDict, lamSqArr_m2):
-    """Two separate Faraday components, averaged within same telescope beam
-    (i.e., unresolved), with a common Burn depolarisation term."""
+    """
+    
+    Two separate Faraday components with external Faraday dispersion
+    With a common depolarisation term
+    Averaged within the same telescope beam (i.e., unresolved)
+    
+    Ref (for individual source component):    
+    Burn (1966) Eq 21
+    Sokoloff et al. (1998) Eq B3
+    O'Sullivan et al. (2012) Eq 11
+    Ma et al. (2019a) Eq 13
+    
+    """
     
     # Calculate the complex fractional q and u spectra
     pArr1 = pDict["fracPol1"] * np.ones_like(lamSqArr_m2)

--- a/RMtools_1D/models_ns/m4.py
+++ b/RMtools_1D/models_ns/m4.py
@@ -13,9 +13,20 @@ from bilby.core.prior import PriorDict, Constraint
 #  quArr       = Complex array containing the Re and Im spectra.              #
 #-----------------------------------------------------------------------------#
 def model(pDict, lamSqArr_m2):
-    """Two separate Faraday components, averaged within same telescope beam
-    (i.e., unresolved), with individual Burn depolarisation terms."""
+    """
     
+    Two separate Faraday components with external Faraday dispersion
+    With individual depolarisation terms
+    Averaged within the same telescope beam (i.e., unresolved)    
+    
+    Ref (for individual source component):    
+    Burn (1966) Eq 21
+    Sokoloff et al. (1998) Eq B3
+    O'Sullivan et al. (2012) Eq 11
+    Ma et al. (2019a) Eq 13
+    
+    """
+
     # Calculate the complex fractional q and u spectra
     pArr1 = pDict["fracPol1"] * np.ones_like(lamSqArr_m2)
     pArr2 = pDict["fracPol2"] * np.ones_like(lamSqArr_m2)
@@ -99,13 +110,13 @@ priors['RM2_radm2'] = bilby.prior.Uniform(
 )
 priors['sigmaRM1_radm2'] = bilby.prior.Uniform(
         minimum=0.0,
-        maximum=1000.0,
+        maximum=100.0,
         name="sigmaRM1_radm2",
         latex_label="$\sigma_{RM,1}$ (rad m$^{-2}$))",
 )
 priors['sigmaRM2_radm2'] = bilby.prior.Uniform(
         minimum=0.0,
-        maximum=1000.0,
+        maximum=100.0,
         name="sigmaRM2_radm2",
         latex_label="$\sigma_{RM,2}$ (rad m$^{-2}$)",
 )

--- a/RMtools_1D/models_ns/m4.py
+++ b/RMtools_1D/models_ns/m4.py
@@ -69,13 +69,13 @@ def converter(parameters):
 priors = PriorDict(conversion_function=converter)
 
 priors['fracPol1'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol1',
     latex_label='$p_1$',
 )
 priors['fracPol2'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol2',
     latex_label='$p_2$',
@@ -127,7 +127,7 @@ priors['delta_RM1_RM2_radm2'] = Constraint(
     latex_label="$\Delta\phi_{1,2}$ (rad m$^{-2}$)",
 )
 priors['sum_p1_p2'] = Constraint(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1,
     name="sum_p1_p2",
     latex_label="$p_1+p_2$)",

--- a/RMtools_1D/models_ns/m5.py
+++ b/RMtools_1D/models_ns/m5.py
@@ -43,7 +43,7 @@ def model(pDict, lamSqArr_m2):
 #-----------------------------------------------------------------------------#
 priors = {
     "fracPol": bilby.prior.Uniform(
-        minimum=0.001, 
+        minimum=0.0, 
         maximum=1.0, 
         name="fracPol", 
         latex_label="$p$"

--- a/RMtools_1D/models_ns/m5.py
+++ b/RMtools_1D/models_ns/m5.py
@@ -14,22 +14,24 @@ import bilby
 def model(pDict, lamSqArr_m2):
     """
     
-    Single Faraday component with external Faraday dispersion
+    Single Faraday component with differential Faraday rotation
+    "Burn slab"
     
     Ref:
-    Burn (1966) Eq 21
-    Sokoloff et al. (1998) Eq B3
-    O'Sullivan et al. (2012) Eq 11
-    Ma et al. (2019a) Eq 13
+    Burn (1966) Eq 18; with N >> (H_r/2H_z^0)^2
+    Sokoloff et al. (1998) Eq 3
+    O'Sullivan et al. (2012) Eq 9
+    Ma et al. (2019a) Eq 12
     
     """
     
     # Calculate the complex fractional q and u spectra
     pArr = pDict["fracPol"] * np.ones_like(lamSqArr_m2)
     quArr = (pArr * np.exp( 2j * (np.radians(pDict["psi0_deg"]) +
-                                  pDict["RM_radm2"] * lamSqArr_m2))
-             * np.exp(-2.0 * pDict["sigmaRM_radm2"]**2.0 
-                      * lamSqArr_m2**2.0))
+                                  (0.5*pDict["deltaRM_radm2"] + 
+                                   pDict["RM_radm2"]) * lamSqArr_m2))
+             * np.sin(pDict["deltaRM_radm2"] * lamSqArr_m2) / 
+               (pDict["deltaRM_radm2"] * lamSqArr_m2))
     
     return quArr
 
@@ -59,10 +61,10 @@ priors = {
         name="RM_radm2",
         latex_label="RM (rad m$^{-2}$)",
     ),
-    "sigmaRM_radm2": bilby.prior.Uniform(
+    "deltaRM_radm2": bilby.prior.Uniform(
         minimum=0.0,
         maximum=100.0,
-        name="sigmaRM_radm2",
-        latex_label="$\sigma_{RM}$ (rad m$^{-2}$)",
+        name="deltaRM_radm2",
+        latex_label="$\Delta{RM}$ (rad m$^{-2}$)",
     ),
 }

--- a/RMtools_1D/models_ns/m6.py
+++ b/RMtools_1D/models_ns/m6.py
@@ -15,24 +15,32 @@ from bilby.core.prior import PriorDict, Constraint
 def model(pDict, lamSqArr_m2):
     """
     
-    Two separate Faraday thin sources
+    Two separate Faraday components with differential Faraday rotation
+    Double "Burn slab"
     Averaged within the same telescope beam (i.e., unresolved)
     
     Ref (for individual source component):
-    Sokoloff et al. (1998) Eq 2
-    O'Sullivan et al. (2012) Eq 8
-    Ma et al. (2019a) Eq 10
+    Burn (1966) Eq 18; with N >> (H_r/2H_z^0)^2
+    Sokoloff et al. (1998) Eq 3
+    O'Sullivan et al. (2012) Eq 9
+    Ma et al. (2019a) Eq 12
     
     """
     
     # Calculate the complex fractional q and u spectra
     pArr1 = pDict["fracPol1"] * np.ones_like(lamSqArr_m2)
     pArr2 = pDict["fracPol2"] * np.ones_like(lamSqArr_m2)
+
     quArr1 = pArr1 * np.exp( 2j * (np.radians(pDict["psi01_deg"]) +
-                                   pDict["RM1_radm2"] * lamSqArr_m2))
+                                   (0.5*pDict["deltaRM1_radm2"] +
+                                    pDict["RM1_radm2"]) * lamSqArr_m2))
     quArr2 = pArr2 * np.exp( 2j * (np.radians(pDict["psi02_deg"]) +
-                                   pDict["RM2_radm2"] * lamSqArr_m2))
-    quArr = (quArr1 + quArr2)
+                                   (0.5*pDict["deltaRM2_radm2"] +
+                                    pDict["RM2_radm2"]) * lamSqArr_m2))
+    quArr = (quArr1 * np.sin(pDict["deltaRM1_radm2"] * lamSqArr_m2) / 
+             (pDict["deltaRM1_radm2"] * lamSqArr_m2) +
+             quArr2 * np.sin(pDict["deltaRM2_radm2"] * lamSqArr_m2) / 
+             (pDict["deltaRM2_radm2"] * lamSqArr_m2))
     
     return quArr
 
@@ -102,6 +110,18 @@ priors['RM2_radm2'] = bilby.prior.Uniform(
     maximum=1100.0,
     name="RM2_radm2",
     latex_label="$\phi_2$ (rad m$^{-2}$)",
+)
+priors['deltaRM1_radm2'] = bilby.prior.Uniform(
+        minimum=0.0,
+        maximum=100.0,
+        name="deltaRM1_radm2",
+        latex_label="$\Delta{RM,1}$ (rad m$^{-2}$))",
+)
+priors['deltaRM2_radm2'] = bilby.prior.Uniform(
+        minimum=0.0,
+        maximum=100.0,
+        name="deltaRM2_radm2",
+        latex_label="$\Delta{RM,2}$ (rad m$^{-2}$)",
 )
 priors['delta_RM1_RM2_radm2'] = Constraint(
     minimum=0,

--- a/RMtools_1D/models_ns/m6.py
+++ b/RMtools_1D/models_ns/m6.py
@@ -72,13 +72,13 @@ def converter(parameters):
 priors = PriorDict(conversion_function=converter)
 
 priors['fracPol1'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol1',
     latex_label='$p_1$',
 )
 priors['fracPol2'] = bilby.prior.Uniform(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1.0,
     name='fracPol2',
     latex_label='$p_2$',
@@ -130,7 +130,7 @@ priors['delta_RM1_RM2_radm2'] = Constraint(
     latex_label="$\Delta\phi_{1,2}$ (rad m$^{-2}$)",
 )
 priors['sum_p1_p2'] = Constraint(
-    minimum=0.001,
+    minimum=0.0,
     maximum=1,
     name="sum_p1_p2",
     latex_label="$p_1+p_2$)",

--- a/RMtools_1D/models_ns/m7.py
+++ b/RMtools_1D/models_ns/m7.py
@@ -14,22 +14,23 @@ import bilby
 def model(pDict, lamSqArr_m2):
     """
     
-    Single Faraday component with external Faraday dispersion
+    Single Faraday component with internal Faraday dispersion
     
     Ref:
-    Burn (1966) Eq 21
-    Sokoloff et al. (1998) Eq B3
-    O'Sullivan et al. (2012) Eq 11
-    Ma et al. (2019a) Eq 13
+    Burn (1966) Eq 18
+    Sokoloff et al. (1998) Eq 34
+    O'Sullivan et al. (2012) Eq 10
+    Ma et al. (2019a) Eq 15
     
     """
     
     # Calculate the complex fractional q and u spectra
     pArr = pDict["fracPol"] * np.ones_like(lamSqArr_m2)
+    para_S = 2. * lamSqArr_m2**2 * pDict["sigmaRM_radm2"]**2
+             - 2j * lamSqArr_m2 * pDict["deltaRM_radm2"]
     quArr = (pArr * np.exp( 2j * (np.radians(pDict["psi0_deg"]) +
                                   pDict["RM_radm2"] * lamSqArr_m2))
-             * np.exp(-2.0 * pDict["sigmaRM_radm2"]**2.0 
-                      * lamSqArr_m2**2.0))
+             * (1 - np.exp(-1.*para_S)) / para_S
     
     return quArr
 
@@ -58,6 +59,12 @@ priors = {
         maximum=1100.0,
         name="RM_radm2",
         latex_label="RM (rad m$^{-2}$)",
+    ),
+    "deltaRM_radm2": bilby.prior.Uniform(
+        minimum=0.0,
+        maximum=100.0,
+        name="deltaRM_radm2",
+        latex_label="$\Delta{RM}$ (rad m$^{-2}$)",
     ),
     "sigmaRM_radm2": bilby.prior.Uniform(
         minimum=0.0,

--- a/RMtools_1D/models_ns/m7.py
+++ b/RMtools_1D/models_ns/m7.py
@@ -26,11 +26,11 @@ def model(pDict, lamSqArr_m2):
     
     # Calculate the complex fractional q and u spectra
     pArr = pDict["fracPol"] * np.ones_like(lamSqArr_m2)
-    para_S = 2. * lamSqArr_m2**2 * pDict["sigmaRM_radm2"]**2
-             - 2j * lamSqArr_m2 * pDict["deltaRM_radm2"]
+    para_S = (2. * lamSqArr_m2**2 * pDict["sigmaRM_radm2"]**2 - 
+             2j * lamSqArr_m2 * pDict["deltaRM_radm2"])
     quArr = (pArr * np.exp( 2j * (np.radians(pDict["psi0_deg"]) +
-                                  pDict["RM_radm2"] * lamSqArr_m2))
-             * (1 - np.exp(-1.*para_S)) / para_S
+                                  pDict["RM_radm2"] * lamSqArr_m2)) * 
+            (1 - np.exp(-1.*para_S)) / para_S)
     
     return quArr
 

--- a/RMtools_1D/models_ns/m7.py
+++ b/RMtools_1D/models_ns/m7.py
@@ -42,7 +42,7 @@ def model(pDict, lamSqArr_m2):
 #-----------------------------------------------------------------------------#
 priors = {
     "fracPol": bilby.prior.Uniform(
-        minimum=0.001, 
+        minimum=0.0, 
         maximum=1.0, 
         name="fracPol", 
         latex_label="$p$"


### PR DESCRIPTION
Hi Cameron,

I've made the following changes for the QU-fitting:

- Added new models for QU-fitting
- Improved the descriptions of the existing models (with relevant references) within each model .py files
- Changed sigma_RM prior from 1000 radm-2 to 100 radm-2 (which I would argue that, for most cases, are more useful & realistic, and of course people applying QU-fitting to very high frequency data can simply change the prior range themselves as they see fit)
- Fixed a bug in the error code in do_QUfit_1D_mnest.py --- compare with line 227 which attempts to load in the model files

Happy to discuss about any of these changes as needed!