### PR TITLE
Fix for QU-fitting: PA0 angle wrapping

### DIFF
--- a/RMtools_1D/do_QUfit_1D_mnest.py
+++ b/RMtools_1D/do_QUfit_1D_mnest.py
@@ -413,7 +413,7 @@ def run_qufit(
         if parNames[i][-3:] == 'deg' and bounds[i][0] == 0. and bounds[i][1] == 180. and wraps[i] == 'periodic':
             # Only try to do it if the units is in deg, bounded within [0., 180.], and is a periodic variable
             summary_tmp = result.get_one_dimensional_median_and_error_bar(parNames[i])
-            if summary.median < 45. or summary.median >= 135.:
+            if summary_tmp.median < 45. or summary_tmp.median >= 135.:
                 # Shift PA by 90 deg
                 result.samples[:,i] += 90.
                 # Keep all values within [0, 180)

--- a/RMtools_1D/do_QUfit_1D_mnest.py
+++ b/RMtools_1D/do_QUfit_1D_mnest.py
@@ -550,7 +550,8 @@ def run_qufit(
                 result.samples[:,i] += 180.
 
     # Resampling to make sure the results show
-    result.samples_to_posterior()
+    if len(rotated_parNames) > 0:
+        result.samples_to_posterior()
 
     cornerFig = result.plot_corner()
 

--- a/RMtools_1D/do_QUfit_1D_mnest.py
+++ b/RMtools_1D/do_QUfit_1D_mnest.py
@@ -538,6 +538,20 @@ def run_qufit(
     #     del(labels[i])
     #     del(p[i])
 
+    # Tricky to get correct PA on the corner plot because of PA wrap!
+    # Solution: Shift PA back to original, and ignore limit of [0, 180]
+
+    for i in range(nDim):
+        if parNames[i] in rotated_parNames:
+            # Rotate back by the 90 deg
+            result.samples[:,i] -= 90.
+            if p[i] > 135.:
+                # In case the PA shown would be << 0 deg
+                result.samples[:,i] += 180.
+
+    # Resampling to make sure the results show
+    result.samples_to_posterior()
+
     cornerFig = result.plot_corner()
 
     # Save the posterior chains to ASCII file

--- a/RMtools_1D/do_QUfit_1D_mnest.py
+++ b/RMtools_1D/do_QUfit_1D_mnest.py
@@ -408,19 +408,24 @@ def run_qufit(
 
     # Shift the angles by 90 deg, if necessary
     # This is to get around the angle wrap issue
-    rotated_parNames = [] ## Store parameters that have been rotated
+    rotated_parNames = []  ## Store parameters that have been rotated
     for i in range(nDim):
-        if parNames[i][-3:] == 'deg' and bounds[i][0] == 0. and bounds[i][1] == 180. and wraps[i] == 'periodic':
+        if (
+            parNames[i][-3:] == "deg"
+            and bounds[i][0] == 0.0
+            and bounds[i][1] == 180.0
+            and wraps[i] == "periodic"
+        ):
             # Only try to do it if the units is in deg, bounded within [0., 180.], and is a periodic variable
             summary_tmp = result.get_one_dimensional_median_and_error_bar(parNames[i])
-            if summary_tmp.median < 45. or summary_tmp.median >= 135.:
+            if summary_tmp.median < 45.0 or summary_tmp.median >= 135.0:
                 # Shift PA by 90 deg
-                result.samples[:,i] += 90.
+                result.samples[:, i] += 90.0
                 # Keep all values within [0, 180)
-                result.samples[:,i] -= (result.samples[:,i] >= 180.)*180.
+                result.samples[:, i] -= (result.samples[:, i] >= 180.0) * 180.0
                 # Keep track of which parameters have been rotated
                 rotated_parNames.append(parNames[i])
-    
+
     # Update the posterior values
     if len(rotated_parNames) > 0:
         result.samples_to_posterior()
@@ -440,8 +445,8 @@ def run_qufit(
         summary = result.get_one_dimensional_median_and_error_bar(parNames[i])
         # Get stats around modal value
         # Shift back by 90 deg if necessary
-        median_val = summary.median - 90.*(parNames[i] in rotated_parNames)
-        median_val += 180.*(median_val < 0.)*(parNames[i] in rotated_parNames)
+        median_val = summary.median - 90.0 * (parNames[i] in rotated_parNames)
+        median_val += 180.0 * (median_val < 0.0) * (parNames[i] in rotated_parNames)
         plus_val = summary.plus
         minus_val = summary.minus
         p[i], errPlus[i], errMinus[i] = (
@@ -544,10 +549,10 @@ def run_qufit(
     for i in range(nDim):
         if parNames[i] in rotated_parNames:
             # Rotate back by the 90 deg
-            result.samples[:,i] -= 90.
-            if p[i] > 135.:
+            result.samples[:, i] -= 90.0
+            if p[i] > 135.0:
                 # In case the PA shown would be << 0 deg
-                result.samples[:,i] += 180.
+                result.samples[:, i] += 180.0
 
     # Resampling to make sure the results show
     if len(rotated_parNames) > 0:


### PR DESCRIPTION
This pull request is to fix Issue #91 

In short, the reported PA0 values and error bars can, in some cases, deviate from the expected values. This is because when evaluating those values from the results of, e.g., nested sampling, the sampler does not correctly take angle wrapping into account.

I have implemented a work-around for this:
If the "initial guess" of the PA0 value is <45 deg or >135 deg, the entire sample (from e.g. nested sampling; confined within [0, 180)) will be shifted up by 90 deg (thus confined within [90, 270)). This sample is then unwrapped to again be confined within [0, 180). Now the PA0 will be wrong by 90 deg, but the angle wrapping issue is eliminated.

The PA0 and uncertainties are then obtained, with the PA0 value shifted back down by 90 deg to return it to the true value.

I have tested the new version (with the fix in place) against the current "old" version, using 10^5 simulated sources. The results are promising (see PDF)

[pa_fix.pdf](https://github.com/CIRADA-Tools/RM-Tools/files/13857115/pa_fix.pdf)



