### PR TITLE
Fix for 3D RM Synthesis --- Outputting NaN for pixels without input data

### DIFF
--- a/RMtools_3D/do_RMsynth_3D.py
+++ b/RMtools_3D/do_RMsynth_3D.py
@@ -645,6 +645,12 @@ def create_peak_maps(FDFcube, phiArr_radm2, phi_axis=0):
     maxPI = np.max(np.abs(FDFcube), axis=phi_axis)
     peakRM_indices = np.argmax(np.abs(FDFcube), axis=phi_axis)
     peakRM = phiArr_radm2[peakRM_indices]
+    # Check for pixels with all NaNs across FD
+    # Write peakRM as NaN (otherwise it takes the first entry in phiArr)
+    nanmap = np.all(np.isnan(FDFcube), axis=0)[0]
+    nanpxlist = np.where(nanmap)
+    if np.shape(nanpxlist)[1] != 0:
+        peakRM[:, nanpxlist[0], nanpxlist[1]] = np.nan
 
     return maxPI, peakRM
 

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -192,15 +192,15 @@ def do_rmsynth_planes(
         arg = np.exp(-2.0j * phiArr_radm2[i] * a)[:, np.newaxis, np.newaxis]
         FDFcube[i, :, :] = KArr * np.sum(pCube * arg, axis=0)
 
-    # Remove redundant dimensions in the FDF array
-    FDFcube = np.squeeze(FDFcube)
-
     # Check for pixels that have Re(FDF)=Im(FDF)=0. across ALL Faraday depths
     # These pixels will be changed to NaN in the output
     zeromap = np.all(FDFcube == 0., axis=0)
     zeropxlist = np.where(zeromap)
     if np.shape(zeropxlist)[1] != 0:
         FDFcube[:, zeropxlist[0], zeropxlist[1]] = np.nan+1.j*np.nan
+
+    # Remove redundant dimensions in the FDF array
+    FDFcube = np.squeeze(FDFcube)
 
     return FDFcube, lam0Sq_m2
 

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -195,6 +195,13 @@ def do_rmsynth_planes(
     # Remove redundant dimensions in the FDF array
     FDFcube = np.squeeze(FDFcube)
 
+    # Check for pixels that have Re(FDF)=Im(FDF)=0. across ALL Faraday depths
+    # These pixels will be changed to NaN in the output
+    zeromap = np.all(FDFcube == 0., axis=0)
+    zeropxlist = np.where(zeromap)
+    if np.shape(zeropxlist)[1] != 0:
+        FDFcube[:, zeropxlist[0], zeropxlist[1]] = np.nan+1.j*np.nan
+
     return FDFcube, lam0Sq_m2
 
 

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -804,12 +804,7 @@ def toscalar(a):
     Returns a scalar version of a Numpy object.
     """
     try:
-        if a.mask.all():
-            # Check if the input array is completely masked
-            # This can happen when, e.g., passing an array full of NaNs through MAD(), and performing toscalar() for this case would return 0.0
-            return np.nan
-        else:
-            return a.item()
+        return a.item()
     except Exception:
         return a
 

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -804,7 +804,12 @@ def toscalar(a):
     Returns a scalar version of a Numpy object.
     """
     try:
-        return a.item()
+        if a.mask.all():
+            # Check if the input array is completely masked
+            # This can happen when, e.g., passing an array full of NaNs through MAD(), and performing toscalar() for this case would return 0.0
+            return np.nan
+        else:
+            return a.item()
     except Exception:
         return a
 


### PR DESCRIPTION
This pull request comes from an action item of the on-going POSSUM Busy Week

It has been identified from the POSSUM 3D pipeline that, for pixels without any valid input data, some of the output data products are set as 0 instead of NaN, which can make it confusing regarding whether those are valid pixels with the output results coincidentally being 0, or that they are actually invalid pixels

This pull request fixes the issue by:
(1) Changing util_misc.toscalar:
Currently, if a fully masked array (e.g., by passing an array full of NaNs through MAD()) is input to toscalar(), the output will be 0.
This can then lead to, for example, the FDF uncertainty being set as 0 instead of NaN (because it can be calculated by toscalar(MAD(...)))

(2) Changing fundamentally how RM-Synthesis is run, through modifying util_RM:
If, for any particular pixel, the Q&U data are all 0 across frequency (e.g., the individual SBID of POSSUM data), then RM-Synthesis will still be run and give FDF=0 across FD.
This has now been fixed by forcing the output FDF to be NaN throughout FD, if the FDF itself is found to be identical to 0 across FD (which result from input Q=U=0)