### PR TITLE
Fix masks

### DIFF
--- a/RMtools_3D/do_RMsynth_3D.py
+++ b/RMtools_3D/do_RMsynth_3D.py
@@ -549,7 +549,8 @@ def writefits(
 
     maxPI, peakRM = create_peak_maps(FDFcube, phiArr_radm2, Ndim - freq_axis)
     # Save a maximum polarised intensity map
-    header["BUNIT"] = headtemplate["BUNIT"]
+    if "BUNIT" in headtemplate:
+        header["BUNIT"] = headtemplate["BUNIT"]
     header["NAXIS" + str(freq_axis)] = 1
     header["CTYPE" + str(freq_axis)] = (
         "DEGENERATE",
@@ -647,10 +648,8 @@ def create_peak_maps(FDFcube, phiArr_radm2, phi_axis=0):
     peakRM = phiArr_radm2[peakRM_indices]
     # Check for pixels with all NaNs across FD
     # Write peakRM as NaN (otherwise it takes the first entry in phiArr)
-    nanmap = np.all(np.isnan(FDFcube), axis=0)[0]
-    nanpxlist = np.where(nanmap)
-    if np.shape(nanpxlist)[1] != 0:
-        peakRM[:, nanpxlist[0], nanpxlist[1]] = np.nan
+    nan_mask = np.all(np.isnan(FDFcube), axis=phi_axis)
+    peakRM[nan_mask] = np.nan
 
     return maxPI, peakRM
 

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -197,9 +197,7 @@ def do_rmsynth_planes(
     # Check for pixels that have Re(FDF)=Im(FDF)=0. across ALL Faraday depths
     # These pixels will be changed to NaN in the output
     zeromap = np.all(FDFcube == 0.0, axis=0)
-    zeropxlist = np.where(zeromap)
-    if np.shape(zeropxlist)[1] != 0:
-        FDFcube[:, zeropxlist[0], zeropxlist[1]] = np.nan + 1.0j * np.nan
+    FDFcube[..., zeromap] = np.nan + 1.0j * np.nan
 
     # Restore if 3D shape
     if nDims == 3:


### PR DESCRIPTION
Small bugfix for how the NaN masks are computed and applied. Currently the masks only work for 3D arrays and makes some assumptions on array shape.

This also generalises the masks for 2D arrays (which is how I ran into issues with the previous implementation).