### PR TITLE
Cubenoisenan

### DIFF
--- a/RMtools_3D/do_fitIcube.py
+++ b/RMtools_3D/do_fitIcube.py
@@ -316,13 +316,14 @@ def cube_noise(datacube, header, freqArr_Hz, threshold=-5):
     return rmsArr, mskSrc
 
 
-def savefits_mask(data, header, outDir, prefixOut):
+def savefits_mask(data, header, outDir, prefixOut, dtFloat):
     """Save the derived mask to a fits file
 
     data:  2D data defining the mask.
     header: header to describe the mask
     outDir: directory to save the mask fits data
     prefixOut: prefix to use on the output name
+    dtFloat: type to use for output file
     """
 
     headMask = strip_fits_dims(header=header, minDim=2)
@@ -331,7 +332,7 @@ def savefits_mask(data, header, outDir, prefixOut):
     if "BUNIT" in headMask:
         del headMask["BUNIT"]
 
-    mskArr = np.where(data > 0, 1.0, np.nan)
+    mskArr = np.where(data > 0, 1.0, np.nan).astype(dtFloat)
     MaskfitsFile = os.path.join(outDir, prefixOut + "mask.fits")
     print("> %s" % MaskfitsFile)
     pf.writeto(MaskfitsFile, mskArr, headMask, output_verify="fix", overwrite=True)
@@ -500,11 +501,11 @@ def make_model_I(
     modelIcube[:] = np.nan
     results = []
 
-    coeffs = np.array([mskArr] * 6)
-    coeffs_error = np.array([mskArr] * 6)
-    reffreq = np.squeeze(np.array([mskArr]))
+    coeffs = np.array([mskArr] * 6, dtype=dtFloat)
+    coeffs_error = np.array([mskArr] * 6, dtype=dtFloat)
+    reffreq = np.squeeze(np.array([mskArr],dtype=dtFloat))
 
-    covars = np.array([[mskArr] * 6] * 6)
+    covars = np.array([[mskArr] * 6] * 6, dtype=dtFloat)
     datacube = np.squeeze(datacube)
 
     # Select only the spectra with emission
@@ -579,7 +580,7 @@ def make_model_I(
 
     if verbose:
         print("Saving mask image.")
-    savefits_mask(data=mskSrc, header=headcoeff, outDir=outDir, prefixOut=prefixOut)
+    savefits_mask(data=mskSrc, header=headcoeff, outDir=outDir, prefixOut=prefixOut, dtFloat=dtFloat)
 
     if verbose:
         print("Saving model I coefficients.")

--- a/RMtools_3D/do_fitIcube.py
+++ b/RMtools_3D/do_fitIcube.py
@@ -295,7 +295,9 @@ def cube_noise(datacube, header, freqArr_Hz, threshold=-5):
 
         else:
             if threshold > 0:
-                idxSky = np.where(dataPlane < threshold)  # replaced cutoff with threshold
+                idxSky = np.where(
+                    dataPlane < threshold
+                )  # replaced cutoff with threshold
             else:
                 idxSky = np.where(dataPlane)
 
@@ -341,6 +343,7 @@ def savefits_mask(data, header, outDir, prefixOut, dtFloat):
     mskArr = np.where(data > 0, 1.0, np.nan).astype(dtFloat)
     MaskfitsFile = os.path.join(outDir, prefixOut + "mask.fits")
     pf.writeto(MaskfitsFile, mskArr, headMask, output_verify="fix", overwrite=True)
+
 
 def savefits_Coeffs(data, dataerr, header, polyOrd, outDir, prefixOut):
     """Save the derived coefficients to a fits file
@@ -507,7 +510,7 @@ def make_model_I(
 
     coeffs = np.array([mskArr] * 6, dtype=dtFloat)
     coeffs_error = np.array([mskArr] * 6, dtype=dtFloat)
-    reffreq = np.squeeze(np.array([mskArr],dtype=dtFloat))
+    reffreq = np.squeeze(np.array([mskArr], dtype=dtFloat))
 
     covars = np.array([[mskArr] * 6] * 6, dtype=dtFloat)
     datacube = np.squeeze(datacube)
@@ -584,7 +587,13 @@ def make_model_I(
 
     if verbose:
         print("Saving mask image.")
-    savefits_mask(data=mskSrc, header=headcoeff, outDir=outDir, prefixOut=prefixOut, dtFloat=dtFloat)
+    savefits_mask(
+        data=mskSrc,
+        header=headcoeff,
+        outDir=outDir,
+        prefixOut=prefixOut,
+        dtFloat=dtFloat,
+    )
 
     if verbose:
         print("Saving model I coefficients.")

--- a/RMtools_3D/rescale_I_model_3D.py
+++ b/RMtools_3D/rescale_I_model_3D.py
@@ -210,7 +210,7 @@ def read_data(basename):
 
     # Get coefficient maps (without knowing how many there are)
     # Reverse index order to match RM-Tools internal ordering (highest to lowest polynomial order)
-    coeffs = np.zeros((6, *old_reffreq_map.shape),dtype=covar_map.dtype)
+    coeffs = np.zeros((6, *old_reffreq_map.shape), dtype=covar_map.dtype)
     for i in range(6):
         try:  # Keep trying higher orders
             data = pf.getdata(basename + f"coeff{i}.fits")

--- a/RMtools_3D/rescale_I_model_3D.py
+++ b/RMtools_3D/rescale_I_model_3D.py
@@ -210,7 +210,7 @@ def read_data(basename):
 
     # Get coefficient maps (without knowing how many there are)
     # Reverse index order to match RM-Tools internal ordering (highest to lowest polynomial order)
-    coeffs = np.zeros((6, *old_reffreq_map.shape))
+    coeffs = np.zeros((6, *old_reffreq_map.shape),dtype=covar_map.dtype)
     for i in range(6):
         try:  # Keep trying higher orders
             data = pf.getdata(basename + f"coeff{i}.fits")
@@ -267,9 +267,9 @@ def rescale_I_model_3D(
         new_errors (3D array): maps of new parameter uncertainties (highest to lowest)
     """
 
-    # Initialize output arrays:
-    new_coeffs = np.zeros_like(coeffs)
-    new_errors = np.zeros_like(coeffs)
+    # Initialize output arrays, keep dtype consistent
+    new_coeffs = np.zeros_like(coeffs, dtype=coeffs.dtype)
+    new_errors = np.zeros_like(coeffs, dtype=coeffs.dtype)
     rs = old_reffreq_map.shape[
         1
     ]  # Get the length of a row, for array indexing later on.


### PR DESCRIPTION
The current implementation of `cube_noise` is quite slow, and a lot slower than it needs to be for datasets that have planes/channels fully flagged. 

This small improvement now checks whether the plane is fully flagged and if so, sets the `noise` and `skymedian` to `np.nan` right away instead of doing a bunch of useless NaN calculations.

This will be particularly important for non-uniform frequency coverage if the users implementation is "simply add NaN channels to make the frequency coverage uniform"

