### PR TITLE
fix 2D peak maps headers. 

### DIFF
--- a/RMtools_3D/RMpeakfit_3D.py
+++ b/RMtools_3D/RMpeakfit_3D.py
@@ -161,13 +161,40 @@ def delete_FITSheader_axis(fitsheader, axis_number):
         except:
             pass
 
+
 def remove_header_third_fourth_axis(header):
     """Removes extra axes from header to compress down to 2 axes"""
     # List of keys related to the 3rd and 4th axes to remove (essentially everything with a '3' or '4')
-    keys_to_remove = ['NAXIS3', 'NAXIS4', 'CRPIX3', 'CRPIX4', 'CDELT3', 'CDELT4', 
-                      'CUNIT3', 'CUNIT4', 'CTYPE3', 'CTYPE4', 'CRVAL3', 'CRVAL4',
-                      'PC1_3', 'PC2_3', 'PC3_3', 'PC4_3', 'PC1_4', 'PC2_4', 'PC3_4', 'PC4_4',
-                      'PC3_1', 'PC3_2', 'PC3_3', 'PC3_4', 'PC4_1', 'PC4_2', 'PC4_3', 'PC4_4']
+    keys_to_remove = [
+        "NAXIS3",
+        "NAXIS4",
+        "CRPIX3",
+        "CRPIX4",
+        "CDELT3",
+        "CDELT4",
+        "CUNIT3",
+        "CUNIT4",
+        "CTYPE3",
+        "CTYPE4",
+        "CRVAL3",
+        "CRVAL4",
+        "PC1_3",
+        "PC2_3",
+        "PC3_3",
+        "PC4_3",
+        "PC1_4",
+        "PC2_4",
+        "PC3_4",
+        "PC4_4",
+        "PC3_1",
+        "PC3_2",
+        "PC3_3",
+        "PC3_4",
+        "PC4_1",
+        "PC4_2",
+        "PC4_3",
+        "PC4_4",
+    ]
 
     all_header_keys = list(header.keys())
 
@@ -175,7 +202,7 @@ def remove_header_third_fourth_axis(header):
         if key in all_header_keys:
             del header[key]
 
-    # Set correct NAXIS 
+    # Set correct NAXIS
     header["NAXIS"] = 2
 
     # Remove STOKES for 2D maps
@@ -185,8 +212,9 @@ def remove_header_third_fourth_axis(header):
     # Finally set correct WCSAXES param if its in there
     if "WCSAXES" in header:
         header["WCSAXES"] = 2
-    
+
     return header
+
 
 def save_maps(map_dict, prefix_path, FDFheader):
     """

--- a/RMtools_3D/RMpeakfit_3D.py
+++ b/RMtools_3D/RMpeakfit_3D.py
@@ -16,7 +16,7 @@ import numpy as np
 from tqdm.auto import trange
 
 from RMtools_3D.do_RMsynth_3D import readFitsCube, readFreqFile
-from RMutils.util_misc import interp_images
+from RMutils.util_misc import interp_images, remove_header_third_fourth_axis
 from RMutils.util_RM import fits_make_lin_axis, measure_FDF_parms
 
 C = 2.997924538e8  # Speed of light [m/s]
@@ -160,59 +160,6 @@ def delete_FITSheader_axis(fitsheader, axis_number):
             del fitsheader[keyword + axis_str]
         except:
             pass
-
-
-def remove_header_third_fourth_axis(header):
-    """Removes extra axes from header to compress down to 2 axes"""
-    # List of keys related to the 3rd and 4th axes to remove (essentially everything with a '3' or '4')
-    keys_to_remove = [
-        "NAXIS3",
-        "NAXIS4",
-        "CRPIX3",
-        "CRPIX4",
-        "CDELT3",
-        "CDELT4",
-        "CUNIT3",
-        "CUNIT4",
-        "CTYPE3",
-        "CTYPE4",
-        "CRVAL3",
-        "CRVAL4",
-        "PC1_3",
-        "PC2_3",
-        "PC3_3",
-        "PC4_3",
-        "PC1_4",
-        "PC2_4",
-        "PC3_4",
-        "PC4_4",
-        "PC3_1",
-        "PC3_2",
-        "PC3_3",
-        "PC3_4",
-        "PC4_1",
-        "PC4_2",
-        "PC4_3",
-        "PC4_4",
-    ]
-
-    for key in keys_to_remove:
-        # Header can dynamically change when keys are removed so use pop
-        header.pop(key, None)
-
-    # Set correct NAXIS
-    header["NAXIS"] = 2
-
-    # Remove STOKES for 2D maps
-    if "STOKES" in header:
-        del header["STOKES"]
-
-    # Finally set correct WCSAXES param if its in there
-    if "WCSAXES" in header:
-        header["WCSAXES"] = 2
-
-    return header
-
 
 def save_maps(map_dict, prefix_path, FDFheader):
     """

--- a/RMtools_3D/RMpeakfit_3D.py
+++ b/RMtools_3D/RMpeakfit_3D.py
@@ -198,7 +198,7 @@ def remove_header_third_fourth_axis(header):
 
     for key in keys_to_remove:
         # Header can dynamically change when keys are removed so use pop
-        header.pop(key, None) 
+        header.pop(key, None)
             del header[key]
 
     # Set correct NAXIS

--- a/RMtools_3D/RMpeakfit_3D.py
+++ b/RMtools_3D/RMpeakfit_3D.py
@@ -196,10 +196,9 @@ def remove_header_third_fourth_axis(header):
         "PC4_4",
     ]
 
-    all_header_keys = list(header.keys())
-
     for key in keys_to_remove:
-        if key in all_header_keys:
+        # Header can dynamically change when keys are removed so use pop
+        header.pop(key, None) 
             del header[key]
 
     # Set correct NAXIS

--- a/RMtools_3D/RMpeakfit_3D.py
+++ b/RMtools_3D/RMpeakfit_3D.py
@@ -199,7 +199,6 @@ def remove_header_third_fourth_axis(header):
     for key in keys_to_remove:
         # Header can dynamically change when keys are removed so use pop
         header.pop(key, None)
-            del header[key]
 
     # Set correct NAXIS
     header["NAXIS"] = 2

--- a/RMtools_3D/do_RMclean_3D.py
+++ b/RMtools_3D/do_RMclean_3D.py
@@ -455,7 +455,7 @@ def main():
         "fitsRMSF",
         metavar="RMSF.fits",
         nargs=1,
-        help="FITS cube containing the RMSF and FWHM image.\n(Cans be any of the RMSF output cubes from do_RMsynth_3D.py)",
+        help="FITS cube containing the RMSF and FWHM image.\n(Cans be any of the RMSF output cubes (so not _FWHM.fits!) from do_RMsynth_3D.py)",
     )
     parser.add_argument(
         "-c",

--- a/RMtools_3D/do_RMsynth_3D.py
+++ b/RMtools_3D/do_RMsynth_3D.py
@@ -44,7 +44,7 @@ import astropy.io.fits as pf
 import astropy.table as at
 import numpy as np
 
-from RMutils.util_misc import interp_images
+from RMutils.util_misc import interp_images, remove_header_third_fourth_axis
 from RMutils.util_RM import do_rmsynth_planes, get_rmsf_planes
 
 if sys.version_info.major == 2:
@@ -474,12 +474,11 @@ def writefits(
             hduLst.writeto(fitsFileOut, output_verify="fix", overwrite=True)
             hduLst.close()
 
-    # Save the RMSF
+    # Save the RMSF: real, im, tot (4D) and FWHM (2D)
     if not not_rmsf:
-        ### TODO: do we want to keep current NAXIS=3 and remove 4th axis
-        ### or do we want to remove both 3rd and 4th axis AND SET NAXIS=2 ??
+        # Create header for RMSF_{real,imag,tot}.fits
 
-        # Put frequency axis first, and reshape to add degenerate axes:
+        # Put frequency axis first, and reshape to add degenerate Stokes axis:
         RMSFcube = np.reshape(RMSFcube, [RMSFcube.shape[0]] + output_axes)
         # Move Faraday depth axis to appropriate position to match header.
         RMSFcube = np.moveaxis(RMSFcube, 0, Ndim - freq_axis)
@@ -497,29 +496,12 @@ def writefits(
         )
         header["BUNIT"] = ""
 
-        rmheader = header.copy()
-        rmheader["BUNIT"] = "rad/m^2"
-        if "BTYPE" in rmheader:
-            del rmheader["BTYPE"]
-        # Because there can be problems with different axes having different FITS keywords,
-        # don't try to remove the FD axis, but just make it degenerate.
-        # Also requires np.expand_dims to set the correct NAXIS.
-        rmheader["NAXIS" + str(freq_axis)] = 1
-        rmheader["CTYPE" + str(freq_axis)] = (
-            "DEGENERATE",
-            "Axis left in to avoid FITS errors",
-        )
-        rmheader["CUNIT" + str(freq_axis)] = ""
-        rmheader["CRVAL" + str(freq_axis)] = 0  # doesnt mean anything
-        stokes_axis = None
-        for axis in range(1, rmheader["NAXIS"] + 1):
-            if "STOKES" in rmheader[f"CTYPE{axis}"]:
-                stokes_axis = axis
-        if stokes_axis is not None:
-            rmheader[f"CTYPE{stokes_axis}"] = (
-                "DEGENERATE",
-                "Axis left in to avoid FITS errors",
-            )
+        # Create header for RMSF_FHWM.fits
+        rmsffwhm_header = header.copy()
+        rmsffwhm_header["BUNIT"] = "rad/m^2"
+        rmsffwhm_header.pop("BTYPE", None)
+        # Remove 3rd and 4th axis, RMSF_FWHM is a plane, like the 2D peak maps
+        rmsffwhm_header = remove_header_third_fourth_axis(rmsffwhm_header)
 
         if write_seperate_FDF:  # more memory efficient as well
             header = _setStokes(header, "Q")
@@ -552,8 +534,9 @@ def writefits(
             del hdu2
             gc.collect()
 
+            print("shape fwhmRMSFCube",np.shape(fwhmRMSFCube))
             hdu3 = pf.PrimaryHDU(
-                np.expand_dims(fwhmRMSFCube.astype(dtFloat), axis=0), rmheader
+                np.expand_dims(fwhmRMSFCube.astype(dtFloat), axis=0), rmsffwhm_header
             )
             fitsFileOut = outDir + "/" + prefixOut + "RMSF_FWHM.fits"
             if verbose:
@@ -571,7 +554,7 @@ def writefits(
             del header["STOKES"]
             hdu2 = pf.ImageHDU(np.abs(RMSFcube).astype(dtFloat), header)
             hdu3 = pf.ImageHDU(
-                np.expand_dims(fwhmRMSFCube.astype(dtFloat), axis=0), rmheader
+                np.expand_dims(fwhmRMSFCube.astype(dtFloat), axis=0), rmsffwhm_header
             )
 
             fitsFileOut = outDir + "/" + prefixOut + "RMSF.fits"

--- a/RMtools_3D/do_RMsynth_3D.py
+++ b/RMtools_3D/do_RMsynth_3D.py
@@ -476,7 +476,7 @@ def writefits(
 
     # Save the RMSF
     if not not_rmsf:
-        ### TODO: do we want to keep current NAXIS=3 and remove 4th axis 
+        ### TODO: do we want to keep current NAXIS=3 and remove 4th axis
         ### or do we want to remove both 3rd and 4th axis AND SET NAXIS=2 ??
 
         # Put frequency axis first, and reshape to add degenerate axes:

--- a/RMtools_3D/do_RMsynth_3D.py
+++ b/RMtools_3D/do_RMsynth_3D.py
@@ -476,6 +476,9 @@ def writefits(
 
     # Save the RMSF
     if not not_rmsf:
+        ### TODO: do we want to keep current NAXIS=3 and remove 4th axis 
+        ### or do we want to remove both 3rd and 4th axis AND SET NAXIS=2 ??
+
         # Put frequency axis first, and reshape to add degenerate axes:
         RMSFcube = np.reshape(RMSFcube, [RMSFcube.shape[0]] + output_axes)
         # Move Faraday depth axis to appropriate position to match header.

--- a/RMtools_3D/do_RMsynth_3D.py
+++ b/RMtools_3D/do_RMsynth_3D.py
@@ -534,7 +534,6 @@ def writefits(
             del hdu2
             gc.collect()
 
-            print("shape fwhmRMSFCube", np.shape(fwhmRMSFCube))
             hdu3 = pf.PrimaryHDU(
                 np.expand_dims(fwhmRMSFCube.astype(dtFloat), axis=0), rmsffwhm_header
             )

--- a/RMutils/util_misc.py
+++ b/RMutils/util_misc.py
@@ -90,6 +90,55 @@ from . import __version__
 
 C = 2.99792458e8
 
+def remove_header_third_fourth_axis(header):
+    """Removes extra axes from header to compress down to 2 axes"""
+    # List of keys related to the 3rd and 4th axes to remove (essentially everything with a '3' or '4')
+    keys_to_remove = [
+        "NAXIS3",
+        "NAXIS4",
+        "CRPIX3",
+        "CRPIX4",
+        "CDELT3",
+        "CDELT4",
+        "CUNIT3",
+        "CUNIT4",
+        "CTYPE3",
+        "CTYPE4",
+        "CRVAL3",
+        "CRVAL4",
+        "PC1_3",
+        "PC2_3",
+        "PC3_3",
+        "PC4_3",
+        "PC1_4",
+        "PC2_4",
+        "PC3_4",
+        "PC4_4",
+        "PC3_1",
+        "PC3_2",
+        "PC3_3",
+        "PC3_4",
+        "PC4_1",
+        "PC4_2",
+        "PC4_3",
+        "PC4_4",
+    ]
+
+    for key in keys_to_remove:
+        # Header can dynamically change when keys are removed so use pop
+        header.pop(key, None)
+
+    # Set correct NAXIS
+    header.set("NAXIS", 2)
+
+    # Remove STOKES axis for 2D maps
+    header.pop("STOKES", None)
+
+    # Finally set correct WCSAXES param
+    header.set("WCSAXES", 2)
+    
+    return header
+
 
 # -----------------------------------------------------------------------------#
 @deprecated(


### PR DESCRIPTION
This commit fixes the 2D peak map headers. The RMSF header implementation is messy and needs to be addressed still before this PR can be merged. But I'm not sure how to best address it as it currently outputs the RMSF as a 3D cube (with one redundant axis) although there are 4 axes in the header.

We could stick with 3 axes or go down to 2 axes. I'm not sure if 2 axes would break the RMclean implementation for example

