### PR TITLE
Chunking: Loading the entire input / output cube onto memory

### DIFF
--- a/RMtools_3D/assemble_chunks.py
+++ b/RMtools_3D/assemble_chunks.py
@@ -51,7 +51,7 @@ def main():
         "-m",
         dest="memmap",
         action="store_true",
-        help="Turn off memory mapping (i.e. Load in the entire output cube to memory). Speed up the assembling process at the cost of memory use."
+        help="Turn off memory mapping (i.e. Load in the entire output cube to memory). Speed up the assembling process at the cost of memory use.",
     )
 
     args = parser.parse_args()

--- a/RMtools_3D/create_chunks.py
+++ b/RMtools_3D/create_chunks.py
@@ -51,7 +51,10 @@ def main():
         "-p", dest="prefix", default=None, help="Prefix of output files [filename]"
     )
     parser.add_argument(
-        "-m", dest="memmap", action="store_true", help="Turn off memory mapping (i.e. Load in the entire input cube to memory). Speed up the chunking process at the cost of memory use."
+        "-m",
+        dest="memmap",
+        action="store_true",
+        help="Turn off memory mapping (i.e. Load in the entire input cube to memory). Speed up the chunking process at the cost of memory use.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
The current behaviour of chunking is that, the complete input / output cube is not loaded onto memory (via memmap = True)

This probably makes sense for many cases (where cube size > memory available).

However, for many cases the amount of memory available may actually be enough to hold the entire cube.

For such cases, loading in the entire cube onto memory can lead to significant speed up (>> factor of 10 in speed)

It may be worthwhile having this (memmap = False) as an option to users (of course, keeping the current memmap = True as the default behaviour)