### PR TITLE
diagnostics: log inputs, computed max_order, and warn when write_new_parameters produces no output

### DIFF
--- a/RMtools_3D/rescale_I_model_3D.py
+++ b/RMtools_3D/rescale_I_model_3D.py
@@ -45,14 +45,32 @@
 #                      (make uniform across all pixels)
 
 import argparse
+import logging
 import multiprocessing as mp
 import os
+import warnings
 from functools import partial
 
 import astropy.io.fits as pf
 import numpy as np
 
 from RMutils.util_misc import FitResult, renormalize_StokesI_model
+
+logger = logging.getLogger(__name__)
+
+
+def _summarize_coeffs(coeffs):
+    """Return a one-line summary string of a coefficient array for logging."""
+    if not hasattr(coeffs, 'shape'):
+        return f"type={type(coeffs).__name__} (no shape)"
+    total = int(np.prod(coeffs.shape))
+    nans = int(np.isnan(coeffs).sum())
+    zeros = int((coeffs == 0.0).sum())
+    finite_nonzero = int(np.count_nonzero(np.isfinite(coeffs) & (coeffs != 0.0)))
+    return (
+        f"shape={coeffs.shape} dtype={coeffs.dtype} total={total} "
+        f"nans={nans} zeros={zeros} finite_nonzero={finite_nonzero}"
+    )
 
 
 def command_line():
@@ -267,6 +285,11 @@ def rescale_I_model_3D(
         new_errors (3D array): maps of new parameter uncertainties (highest to lowest)
     """
 
+    logger.info(
+        "rescale_I_model_3D: begin. num_cores=%d fit_function=%s input coeffs %s",
+        num_cores, fit_function, _summarize_coeffs(coeffs),
+    )
+
     # Initialize output arrays, keep dtype consistent
     new_coeffs = np.zeros_like(coeffs, dtype=coeffs.dtype)
     new_errors = np.zeros_like(coeffs, dtype=coeffs.dtype)
@@ -294,6 +317,11 @@ def rescale_I_model_3D(
     for i, (p, perror) in enumerate(results):
         new_coeffs[:, i // rs, i % rs] = p
         new_errors[:, i // rs, i % rs] = perror
+
+    logger.info(
+        "rescale_I_model_3D: end. output new_coeffs %s",
+        _summarize_coeffs(new_coeffs),
+    )
 
     return new_freq_map, new_coeffs, new_errors
 
@@ -326,19 +354,51 @@ def write_new_parameters(
         np.sum(np.any((new_coeffs != 0.0) & (~np.isnan(new_coeffs)), axis=(1, 2))) - 1
     )
 
+    logger.info(
+        "write_new_parameters: input new_coeffs %s -> computed max_order=%d, "
+        "will write %d newcoeff*.fits + %d newcoeff*err.fits files with basename %r",
+        _summarize_coeffs(new_coeffs), int(max_order),
+        max(max_order + 1, 0), max(max_order + 1, 0), out_basename,
+    )
+
+    if max_order < 0:
+        # Every plane of new_coeffs is zero or NaN. The write loop below would
+        # be range(0) — nothing written, no exception raised. Historically this
+        # was silent; downstream callers that expect newcoeff*.fits to exist
+        # (e.g. POSSUM_Polarimetry_Pipeline's fracpol3d_Irescale) can then
+        # destroy the input coeff*.fits and hit a FileNotFoundError much later,
+        # far from the actual root cause. Make the condition loudly visible.
+        msg = (
+            "RMtools_3D.rescale_I_model_3D.write_new_parameters: no output "
+            "written because computed max_order=-1 (every plane of new_coeffs "
+            "is 0.0 or NaN). This usually means rescale_I_model_3D received "
+            "unusable inputs or the per-pixel rescale failed everywhere. "
+            f"out_basename={out_basename!r}"
+        )
+        logger.warning(msg)
+        warnings.warn(msg, UserWarning, stacklevel=2)
+        return
+
+    written = []
     for i in range(max_order + 1):
+        coeff_path = out_basename + f"newcoeff{i}.fits"
+        err_path = out_basename + f"newcoeff{i}err.fits"
         pf.writeto(
-            out_basename + f"newcoeff{i}.fits",
+            coeff_path,
             new_coeffs[5 - i],
             header=out_header,
             overwrite=overwrite,
         )
         pf.writeto(
-            out_basename + f"newcoeff{i}err.fits",
+            err_path,
             new_errors[5 - i],
             header=out_header,
             overwrite=overwrite,
         )
+        written.extend((coeff_path, err_path))
+        logger.info("write_new_parameters: wrote %s and %s", coeff_path, err_path)
+
+    logger.info("write_new_parameters: end. wrote %d files.", len(written))
 
 
 # -----------------------------------------------------------------------------#

--- a/RMtools_3D/rescale_I_model_3D.py
+++ b/RMtools_3D/rescale_I_model_3D.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 
 def _summarize_coeffs(coeffs):
     """Return a one-line summary string of a coefficient array for logging."""
-    if not hasattr(coeffs, 'shape'):
+    if not hasattr(coeffs, "shape"):
         return f"type={type(coeffs).__name__} (no shape)"
     total = int(np.prod(coeffs.shape))
     nans = int(np.isnan(coeffs).sum())
@@ -287,7 +287,9 @@ def rescale_I_model_3D(
 
     logger.info(
         "rescale_I_model_3D: begin. num_cores=%d fit_function=%s input coeffs %s",
-        num_cores, fit_function, _summarize_coeffs(coeffs),
+        num_cores,
+        fit_function,
+        _summarize_coeffs(coeffs),
     )
 
     # Initialize output arrays, keep dtype consistent
@@ -357,8 +359,11 @@ def write_new_parameters(
     logger.info(
         "write_new_parameters: input new_coeffs %s -> computed max_order=%d, "
         "will write %d newcoeff*.fits + %d newcoeff*err.fits files with basename %r",
-        _summarize_coeffs(new_coeffs), int(max_order),
-        max(max_order + 1, 0), max(max_order + 1, 0), out_basename,
+        _summarize_coeffs(new_coeffs),
+        int(max_order),
+        max(max_order + 1, 0),
+        max(max_order + 1, 0),
+        out_basename,
     )
 
     if max_order < 0:


### PR DESCRIPTION
## Motivation

`write_new_parameters` currently derives the number of output files from a `max_order` heuristic on `new_coeffs`:

```python
max_order = (
    np.sum(np.any((new_coeffs != 0.0) & (~np.isnan(new_coeffs)), axis=(1, 2))) - 1
)
for i in range(max_order + 1):
    pf.writeto(...)
```

When `new_coeffs` is entirely `0.0` or NaN across every plane, `max_order` resolves to `-1`, the write loop becomes `range(0)`, and **no files are written, no exception is raised, no log line is emitted**.

Downstream consumers that assume `newcoeff*.fits` exist can be hurt badly by this silent path. In the CIRADA POSSUM pipeline (`POSSUM_Polarimetry_Pipeline/pipeline/modules/fracpol3d_Irescale.py`), a subsequent delete-then-rename block would destroy the input `coeff*.fits` files and only crash much later with a `FileNotFoundError` at `pf.getdata(coeff0.fits)`, far from the root cause. That has now been fixed defensively on the pipeline side ([POSSUM_Polarimetry_Pipeline#33](https://github.com/CIRADA-Tools/POSSUM_Polarimetry_Pipeline/pull/33)), but the underlying silent no-op inside RMtools deserves visibility here too.

Observed: tile 6614, 943MHz, RMtools 1.4.11 in production — the writer produced zero output files with no warning; only became visible when a downstream getdata crashed.

## Changes (all diagnostics — no behaviour change on the happy path)

- Add a module-level `logger` and a small `_summarize_coeffs` helper that returns a compact one-line descriptor of a coefficient array (`shape`, `dtype`, total elements, nan count, zero count, finite-nonzero count).
- `rescale_I_model_3D`: log input coeffs summary at the start and output `new_coeffs` summary at the end (INFO).
- `write_new_parameters`: log input summary and the computed `max_order` up front; log every file written with its full path; log a final total-files-written count at the end (INFO).
- `write_new_parameters`: when `max_order < 0`, emit **both** `logger.warning` and `warnings.warn(UserWarning)` with a clear message identifying the condition ("every plane of new_coeffs is 0.0 or NaN"), then `return` explicitly. The historical behaviour of writing no files is preserved; the reason is now visible even to callers that haven't configured logging.

## Non-goals

- **No behaviour change on inputs that previously wrote files.** Same files, same content, same order.
- Not changing the `max_order` heuristic itself. If it turns out the heuristic is wrong (e.g. failing on valid low-order fits under some conditions), that's a separate fix.
- Not raising instead of warning. `warnings.warn(UserWarning)` is the loudest visibility change that doesn't break existing callers that treat the empty-output case as valid.

## Test plan

- [ ] Existing tests should pass unchanged (only additive log/warning code paths).
- [ ] Manually construct `new_coeffs` filled with NaN, call `write_new_parameters` — expect a `UserWarning` and a logger warning, no files written (as before).
- [ ] Manually construct valid `new_coeffs` — expect INFO log lines showing the summary, `max_order`, and per-file paths, plus the normal FITS output files.